### PR TITLE
More clippy lints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,8 @@ rand_xoshiro = { version = "0.7.0", features = ["serde"] }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.142"
 signal-hook = "0.3.18"
+
+[lints.clippy]
+match_same_arms = "warn"
+or_fun_call = "warn"
+semicolon_if_nothing_returned = "warn"

--- a/src/action.rs
+++ b/src/action.rs
@@ -39,22 +39,22 @@ impl GameState {
                     Card {
                         suit: crate::cards::Suit::Clubs,
                         rank: e as u8,
-                        face_up: false,
+                        is_facing_up: false,
                     },
                     Card {
                         suit: crate::cards::Suit::Hearts,
                         rank: e as u8,
-                        face_up: false,
+                        is_facing_up: false,
                     },
                     Card {
                         suit: crate::cards::Suit::Clubs,
                         rank: e as u8,
-                        face_up: false,
+                        is_facing_up: false,
                     },
                     Card {
                         suit: crate::cards::Suit::Hearts,
                         rank: e as u8,
-                        face_up: false,
+                        is_facing_up: false,
                     },
                 ]
                 .repeat(2)
@@ -82,7 +82,7 @@ impl GameState {
         };
 
         for row in &mut state.stacks {
-            row.last_mut().unwrap().face_up = true;
+            row.last_mut().unwrap().is_facing_up = true;
         }
 
         state
@@ -99,7 +99,7 @@ impl GameState {
             Some(e) => e.rank.checked_sub(1).and_then(|wanted_rank| {
                 last_group.contains_rank(wanted_rank).then(|| CardRange {
                     suit: last_group.suit,
-                    face_up: last_group.face_up,
+                    is_facing_up: last_group.is_facing_up,
                     rank: (last_group.rank.clone().next_back().unwrap()..=e.rank - 1).rev(),
                 })
             }),
@@ -110,14 +110,14 @@ impl GameState {
     pub fn move_from_to(&self, from: usize, to: usize) -> Option<Action> {
         let moved_cards = self.can_move_to(from, to)?;
 
-        let set_face_up = self.stacks[from]
+        let set_is_facing_up = self.stacks[from]
             .len()
             .checked_sub(moved_cards.len() + 1)
-            .is_some_and(|i| !self.stacks[from][i].face_up);
+            .is_some_and(|i| !self.stacks[from][i].is_facing_up);
 
         Some(Action::Move {
             range: moved_cards,
-            flip_card: set_face_up,
+            flip_card: set_is_facing_up,
             from,
             to,
         })
@@ -135,13 +135,13 @@ impl GameState {
                 self.stacks[to].extend(range);
 
                 if flip_card {
-                    self.stacks[from].last_mut().unwrap().face_up = true;
+                    self.stacks[from].last_mut().unwrap().is_facing_up = true;
                 }
             }
             Action::Deal => {
                 let cards = self.deck.split_off(self.deck.len() - 10);
                 for (stack, mut card) in self.stacks.iter_mut().zip(cards.into_iter()) {
-                    card.face_up = true;
+                    card.is_facing_up = true;
                     stack.push(card);
                 }
             }
@@ -153,7 +153,7 @@ impl GameState {
                 self.stacks[stack].truncate(self.stacks[stack].len() - 13);
                 self.completed_stacks.push(suit);
                 if flip_card {
-                    self.stacks[stack].last_mut().unwrap().face_up = true;
+                    self.stacks[stack].last_mut().unwrap().is_facing_up = true;
                 }
             }
             Action::Cheat(cheat) => apply_cheat(self, cheat),
@@ -169,7 +169,7 @@ impl GameState {
                 range,
             } => {
                 if flip_card {
-                    self.stacks[from].last_mut().unwrap().face_up = false;
+                    self.stacks[from].last_mut().unwrap().is_facing_up = false;
                 }
 
                 self.stacks[to].truncate(self.stacks[to].len() - range.len());
@@ -186,13 +186,13 @@ impl GameState {
                 flip_card,
             } => {
                 if flip_card {
-                    self.stacks[stack].last_mut().unwrap().face_up = false;
+                    self.stacks[stack].last_mut().unwrap().is_facing_up = false;
                 }
                 self.completed_stacks.pop();
                 self.stacks[stack].extend(CardRange {
                     suit,
                     rank: (0..=12).rev(),
-                    face_up: true,
+                    is_facing_up: true,
                 });
             }
             Action::Cheat(cheat) => {

--- a/src/cards.rs
+++ b/src/cards.rs
@@ -28,10 +28,8 @@ pub enum CardColor {
 impl Suit {
     pub fn get_color(&self) -> CardColor {
         match self {
-            Suit::Clubs => CardColor::Black,
-            Suit::Hearts => CardColor::Red,
-            Suit::Diamonds => CardColor::Red,
-            Suit::Spades => CardColor::Black,
+            Suit::Hearts | Suit::Diamonds => CardColor::Red,
+            Suit::Clubs | Suit::Spades => CardColor::Black,
         }
     }
 
@@ -87,8 +85,9 @@ impl<'de> Deserialize<'de> for Card {
             .map_err(|_| D::Error::custom("Expected 3 length string"))?;
 
         Ok(Card {
-            suit: Suit::from_char(suit).ok_or(D::Error::custom("Unexpected suit"))?,
-            rank: Card::get_rank_from_char(rank).ok_or(D::Error::custom("Unexpected rank"))?,
+            suit: Suit::from_char(suit).ok_or_else(|| D::Error::custom("Unexpected suit"))?,
+            rank: Card::get_rank_from_char(rank)
+                .ok_or_else(|| D::Error::custom("Unexpected rank"))?,
             face_up: match face_up {
                 FACE_UP_CHAR => true,
                 FACE_DOWN_CHAR => false,
@@ -184,9 +183,9 @@ impl<'de> Deserialize<'de> for CardRange {
             .map_err(|_| D::Error::custom("Expected 5 length string"))?;
 
         Ok(CardRange {
-            suit: Suit::from_char(suit).ok_or(Error::custom("Bad suit"))?,
-            rank: (Card::get_rank_from_char(to).ok_or(Error::custom("Bad to rank"))?
-                ..=Card::get_rank_from_char(from).ok_or(Error::custom("Bad from rank"))?)
+            suit: Suit::from_char(suit).ok_or_else(|| Error::custom("Bad suit"))?,
+            rank: (Card::get_rank_from_char(to).ok_or_else(|| Error::custom("Bad to rank"))?
+                ..=Card::get_rank_from_char(from).ok_or_else(|| Error::custom("Bad from rank"))?)
                 .rev(),
             face_up: match face_up {
                 FACE_UP_CHAR => true,

--- a/src/cards.rs
+++ b/src/cards.rs
@@ -63,7 +63,7 @@ impl Serialize for Card {
             "{}{}{}",
             self.suit,
             self.get_rank_char(),
-            if self.face_up {
+            if self.is_facing_up {
                 FACE_UP_CHAR
             } else {
                 FACE_DOWN_CHAR
@@ -78,7 +78,7 @@ impl<'de> Deserialize<'de> for Card {
     where
         D: Deserializer<'de>,
     {
-        let [suit, rank, face_up] = String::deserialize(deserializer)?
+        let [suit, rank, is_facing_up] = String::deserialize(deserializer)?
             .chars()
             .collect::<Vec<char>>()
             .try_into()
@@ -88,10 +88,10 @@ impl<'de> Deserialize<'de> for Card {
             suit: Suit::from_char(suit).ok_or_else(|| D::Error::custom("Unexpected suit"))?,
             rank: Card::get_rank_from_char(rank)
                 .ok_or_else(|| D::Error::custom("Unexpected rank"))?,
-            face_up: match face_up {
+            is_facing_up: match is_facing_up {
                 FACE_UP_CHAR => true,
                 FACE_DOWN_CHAR => false,
-                _ => Err(D::Error::custom("Unexpected face_up"))?,
+                _ => Err(D::Error::custom("Unexpected is_facing_up"))?,
             },
         })
     }
@@ -101,7 +101,7 @@ impl<'de> Deserialize<'de> for Card {
 pub struct Card {
     pub suit: Suit,
     pub rank: u8,
-    pub face_up: bool,
+    pub is_facing_up: bool,
 }
 
 impl Card {
@@ -136,7 +136,7 @@ impl Card {
 
 impl Display for Card {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        if self.face_up {
+        if self.is_facing_up {
             write!(f, "{}{}", self.get_rank_char(), self.suit)
         } else {
             write!(f, "██")
@@ -148,7 +148,7 @@ impl Display for Card {
 pub struct CardRange {
     pub suit: Suit,
     pub rank: Rev<RangeInclusive<u8>>,
-    pub face_up: bool,
+    pub is_facing_up: bool,
 }
 
 impl Serialize for CardRange {
@@ -161,7 +161,7 @@ impl Serialize for CardRange {
             self.suit,
             Card::rank_to_char(self.rank.clone().next().unwrap()),
             Card::rank_to_char(self.rank.clone().next_back().unwrap()),
-            if self.face_up {
+            if self.is_facing_up {
                 FACE_UP_CHAR
             } else {
                 FACE_DOWN_CHAR
@@ -176,7 +176,7 @@ impl<'de> Deserialize<'de> for CardRange {
     where
         D: Deserializer<'de>,
     {
-        let [suit, from, _, to, face_up] = String::deserialize(deserializer)?
+        let [suit, from, _, to, is_facing_up] = String::deserialize(deserializer)?
             .chars()
             .collect::<Vec<char>>()
             .try_into()
@@ -187,10 +187,10 @@ impl<'de> Deserialize<'de> for CardRange {
             rank: (Card::get_rank_from_char(to).ok_or_else(|| Error::custom("Bad to rank"))?
                 ..=Card::get_rank_from_char(from).ok_or_else(|| Error::custom("Bad from rank"))?)
                 .rev(),
-            face_up: match face_up {
+            is_facing_up: match is_facing_up {
                 FACE_UP_CHAR => true,
                 FACE_DOWN_CHAR => false,
-                _ => Err(D::Error::custom("Unexpected face_up"))?,
+                _ => Err(D::Error::custom("Unexpected is_facing_up"))?,
             },
         })
     }
@@ -213,7 +213,7 @@ impl CardRange {
         Some(Card {
             rank: self.rank.clone().next()?,
             suit: self.suit,
-            face_up: self.face_up,
+            is_facing_up: self.is_facing_up,
         })
     }
 }
@@ -224,7 +224,7 @@ impl Iterator for CardRange {
         self.rank.next().map(|e| Card {
             suit: self.suit,
             rank: e,
-            face_up: self.face_up,
+            is_facing_up: self.is_facing_up,
         })
     }
 
@@ -232,7 +232,7 @@ impl Iterator for CardRange {
         Some(Card {
             rank: self.rank.clone().next()? + 1 - self.rank.len() as u8,
             suit: self.suit,
-            face_up: self.face_up,
+            is_facing_up: self.is_facing_up,
         })
     }
 }
@@ -246,7 +246,7 @@ impl<'a> Iterator for Groups<'a> {
         let mut last = first;
         let mut last_index = 0;
         for (inex, &card) in self.0.iter().enumerate().skip(1) {
-            if first.face_up && card.face_up && card.suit == last.suit && card.rank + 1 == last.rank
+            if first.is_facing_up && card.is_facing_up && card.suit == last.suit && card.rank + 1 == last.rank
             {
                 last = card;
                 last_index = inex;
@@ -259,7 +259,7 @@ impl<'a> Iterator for Groups<'a> {
 
         Some(CardRange {
             suit: first.suit,
-            face_up: first.face_up,
+            is_facing_up: first.is_facing_up,
             rank: (last.rank..=first.rank).rev(),
         })
     }

--- a/src/cheats.rs
+++ b/src/cheats.rs
@@ -69,7 +69,7 @@ pub fn apply_cheat(game_state: &mut GameState, cheat: Cheat) {
 
             cards.zip(game_state.stacks.iter_mut()).for_each(|(card, stack)| {
                 stack.push(card);
-            })
+            });
         }
     }
 }

--- a/src/cheats.rs
+++ b/src/cheats.rs
@@ -30,7 +30,7 @@ pub fn generate_cheat(game_state: &GameState, cheat_number: usize) -> Option<Che
         1 => {
             Some(Cheat::HarvestTopRow{
                 turn_over_cards: game_state.stacks.clone().map(
-                    |i| i.len() >=2 && !i[i.len()-2].face_up
+                    |i| i.len() >=2 && !i[i.len()-2].is_facing_up
                 )
             })
         },
@@ -49,7 +49,7 @@ pub fn apply_cheat(game_state: &mut GameState, cheat: Cheat) {
 
             game_state.stacks.iter_mut().zip(turn_over_cards).for_each(|(stack, turn_over) | {
                 if turn_over {
-                    stack.last_mut().unwrap().face_up = true;
+                    stack.last_mut().unwrap().is_facing_up = true;
                 }
             });
         },
@@ -61,7 +61,7 @@ pub fn apply_cheat(game_state: &mut GameState, cheat: Cheat) {
                 |e| Card {
                     suit,
                     rank: *e,
-                    face_up: true,
+                    is_facing_up: true,
                 }
             );
 
@@ -79,13 +79,13 @@ pub fn undo_cheat(game_state: &mut GameState, cheat: Cheat) {
         Cheat::HarvestTopRow { turn_over_cards } => {
             game_state.stacks.iter_mut().zip(turn_over_cards).for_each(|(stack, turn_over) | {
                 if turn_over {
-                    stack.last_mut().unwrap().face_up = false;
+                    stack.last_mut().unwrap().is_facing_up = false;
                 }
             });
 
             let cards = game_state.deck.split_off(game_state.deck.len() - 10);
             for (stack, mut card) in game_state.stacks.iter_mut().zip(cards.into_iter()) {
-                card.face_up = true;
+                card.is_facing_up = true;
                 stack.push(card);
             }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -70,7 +70,7 @@ impl StateWithUndoHistory {
                 suit,
                 stack,
                 flip_card,
-            })
+            });
         }
     }
 
@@ -174,7 +174,7 @@ fn run_game(running: &AtomicBool) {
             Input::ExitMenu => match input_state {
                 InputState::CheatMenu => {
                     input_state = InputState::SelectSource;
-                    changed = true
+                    changed = true;
                 }
                 _ => break,
             },

--- a/src/main.rs
+++ b/src/main.rs
@@ -61,7 +61,7 @@ impl StateWithUndoHistory {
                 actions.push((
                     g.suit,
                     index,
-                    stack.len() > 13 && !stack[stack.len() - 14].face_up,
+                    stack.len() > 13 && !stack[stack.len() - 14].is_facing_up,
                 ));
             }
         }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -67,7 +67,7 @@ fn draw_game(
         stdout.execute(ResetColor)?;
 
         for card in Groups(row) {
-            if !card.face_up {
+            if !card.is_facing_up {
                 stdout.execute(SetForegroundColor(Color::Blue))?;
             } else if card.suit.get_color() == CardColor::Red {
                 stdout.execute(SetForegroundColor(Color::Red))?;

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -126,7 +126,7 @@ pub fn draw(game_state: &GameState, input_state: InputState) -> Result<(), io::E
             CardColor::Red => Color::Red,
             CardColor::Black => Color::White,
         }))?;
-        print!(" [{suit}] ")
+        print!(" [{suit}] ");
     }
     print!("\r\n\r\n");
 


### PR DESCRIPTION
Nice game! I added more clippy lints to fix basic stuff.

 I think that the game could be improved in some other ways, but this PR doesnt cover them:

- You can use a `Peekable<_>` instead of cloning the `Rev<_>` (for `CardRange.rank`)
- If I'm not mistaking, the program can panic at `main.rs:120` (restart without save) => I think that a better error handling would be nice rather than panicking. (also, from my pov, there are a lot of `.unwrap()` in the overall code)